### PR TITLE
Update protobuf-codegen to 3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.78.0-buster
 
 RUN apt-get update && apt-get install -y protobuf-compiler
-RUN cargo install protobuf-codegen@3.4.0
+RUN cargo install protobuf-codegen@3.5.1
 
 RUN mkdir /cmd
 COPY entrypoint.sh /cmd/entrypoint.sh


### PR DESCRIPTION
Version 3.5.0 produced compilation [error](https://github.com/project-echo/server-robot-upload-commspec/actions/runs/10111369941/job/27963171371#step:2:559), but 3.5.1 is fine again.